### PR TITLE
[PR1] DEV-8: DataTransfer, getPackets and update

### DIFF
--- a/src/DataTransfer/dataTransfer.go
+++ b/src/DataTransfer/dataTransfer.go
@@ -1,0 +1,15 @@
+package dataTransfer
+
+//"github.com/HyperloopUPV-H8/Backend-H8/src/DataTransfer/podDataCreator"
+//"github.com/HyperloopUPV-H8/Backend-H8/Shared/packetParser"
+
+type DataTransfer struct {
+	pd PodData
+}
+
+func (dt DataTransfer) Invoke(getPackets func() []packetParser.PacketUpdate) {
+	for {
+		packets := getPackets()
+		pd.UpdatePackets(packets)
+	}
+}


### PR DESCRIPTION
Function Invoke receives the funtion getPackets as an argument, and in an infinite for, it takes them and update packages of the PodData.
Imports do not work