### PR TITLE
[PR1] DEV-11 Packet parser returns hex value and changes in podData structs

### DIFF
--- a/src/DataTransfer/domain/board.go
+++ b/src/DataTransfer/domain/board.go
@@ -3,13 +3,13 @@ package domain
 import excelParser "github.com/HyperloopUPV-H8/Backend-H8/Shared/ExcelParser/domain/board"
 
 type Board struct {
-	Name    string
-	Packets map[uint16]Packet
+	Name                 string
+	PacketTimestampPairs map[uint16]PacketTimestampPair
 }
 
 func NewBoard(rawBoard excelParser.Board) Board {
 	return Board{
-		Name:    rawBoard.Name,
-		Packets: NewPackets(rawBoard.GetPackets()),
+		Name:                 rawBoard.Name,
+		PacketTimestampPairs: NewPacketTimestampPairs(rawBoard.GetPackets()),
 	}
 }

--- a/src/DataTransfer/domain/packet.go
+++ b/src/DataTransfer/domain/packet.go
@@ -24,11 +24,12 @@ type Packet struct {
 	CycleTime    int64
 }
 
-func (packetTimestampPair *PacketTimestampPair) UpdatePacket(data packetParser.PacketUpdate) {
+func (packetTimestampPair *PacketTimestampPair) UpdatePacket(pu packetParser.PacketUpdate) {
 	packetTimestampPair.Packet.Count++
-	packetTimestampPair.Packet.CycleTime = data.Timestamp.Sub(packetTimestampPair.Timestamp).Milliseconds()
-	packetTimestampPair.Timestamp = data.Timestamp
-	for name, value := range data.UpdatedValues {
+	packetTimestampPair.Packet.HexValue = pu.HexValue
+	packetTimestampPair.Packet.CycleTime = pu.Timestamp.Sub(packetTimestampPair.Timestamp).Milliseconds()
+	packetTimestampPair.Timestamp = pu.Timestamp
+	for name, value := range pu.UpdatedValues {
 		packetTimestampPair.Packet.Measurements[name].Value.Update(value)
 	}
 }

--- a/src/DataTransfer/domain/pod_data.go
+++ b/src/DataTransfer/domain/pod_data.go
@@ -14,11 +14,11 @@ func (podData *PodData) UpdatePacket(pu packetParser.PacketUpdate) {
 	packet.UpdatePacket(pu)
 }
 
-func (podData *PodData) GetPacket(id uint16) *Packet {
+func (podData *PodData) GetPacket(id uint16) *PacketTimestampPair {
 	for _, board := range podData.Boards {
-		packet, exists := board.Packets[id]
+		packetTimeStampPair, exists := board.PacketTimestampPairs[id]
 		if exists {
-			return &packet
+			return &packetTimeStampPair
 		}
 	}
 	return nil
@@ -34,8 +34,8 @@ func getBoards(rawBoards map[string]excelParser.Board) map[string]Board {
 	boards := make(map[string]Board)
 	for name, board := range rawBoards {
 		board := Board{
-			Name:    name,
-			Packets: NewPackets(board.GetPackets()),
+			Name:                 name,
+			PacketTimestampPairs: NewPacketTimestampPairs(board.GetPackets()),
 		}
 		boards[board.Name] = board
 	}

--- a/src/Shared/PacketAdapter/domain/packet_parser.go
+++ b/src/Shared/PacketAdapter/domain/packet_parser.go
@@ -74,7 +74,7 @@ func (parser PacketParser) Decode(data []byte) PacketUpdate {
 	id := serde.DecodeID(dataReader)
 	values := parser.decodePacket(parser.packetTypes[id], dataReader)
 
-	return NewPacketUpdate(id, values)
+	return NewPacketUpdate(id, values, dataReader.Bytes())
 }
 
 func (parser PacketParser) decodePacket(measurements PacketMeasurements, bytes io.Reader) map[Name]any {

--- a/src/Shared/PacketAdapter/domain/packet_update.go
+++ b/src/Shared/PacketAdapter/domain/packet_update.go
@@ -6,13 +6,15 @@ import (
 
 type PacketUpdate struct {
 	ID            ID
+	HexValue      []byte
 	UpdatedValues map[string]any
 	Timestamp     time.Time
 }
 
-func NewPacketUpdate(id ID, update map[string]any) PacketUpdate {
+func NewPacketUpdate(id ID, update map[string]any, hexValues []byte) PacketUpdate {
 	return PacketUpdate{
 		ID:            id,
+		HexValue:      hexValues,
 		UpdatedValues: update,
 		Timestamp:     time.Now(),
 	}


### PR DESCRIPTION
We are going to show the hexadecimal value of the packets in the frontend, so I made the necessary changes to be able to send that information.

I also separated the timestamp from the Packet as timestamp is not really a Packet property. 