### PR TITLE
[PR1] DEV-23 added support to enable and disable the data logger

### DIFF
--- a/src/Shared/Logger/infra/value_timestamp.go
+++ b/src/Shared/Logger/infra/value_timestamp.go
@@ -14,7 +14,7 @@ type ValueTimestamp struct {
 
 func NewValue(timestamp time.Time, measurement value.Value) ValueTimestamp {
 	return ValueTimestamp{
-		value:     measurement.ToDisplayUnitsString(),
+		value:     measurement.ToDisplayString(),
 		timestamp: timestamp,
 	}
 }

--- a/src/Shared/Logger/infra/value_timestamp.go
+++ b/src/Shared/Logger/infra/value_timestamp.go
@@ -14,7 +14,7 @@ type ValueTimestamp struct {
 
 func NewValue(timestamp time.Time, measurement value.Value) ValueTimestamp {
 	return ValueTimestamp{
-		value:     measurement.ToDisplayString(),
+		value:     measurement.ToDisplayUnitsString(),
 		timestamp: timestamp,
 	}
 }

--- a/src/Shared/Server/infra/http.go
+++ b/src/Shared/Server/infra/http.go
@@ -13,22 +13,24 @@ const (
 	defaultStaticPath = ""
 )
 
-type HTTPServer[R, S any] struct {
-	router     *mux.Router
-	page       spaHandler
-	PacketRecv chan R
-	OrderSend  chan S
+type HTTPServer[D, O, M any] struct {
+	router      *mux.Router
+	page        spaHandler
+	PacketRecv  chan D
+	OrderSend   chan O
+	MessageRecv chan M
 }
 
-func New[R, S any](rx chan R, tx chan S) HTTPServer[R, S] {
-	return HTTPServer[R, S]{
-		router:     mux.NewRouter(),
-		page:       NewPage(defaultStaticPath, defaultIndexPath),
-		PacketRecv: rx,
-		OrderSend:  tx,
+func New[D, O, M any](dataIn chan D, orderOut chan O, messageIn chan M) HTTPServer[D, O, M] {
+	return HTTPServer[D, O, M]{
+		router:      mux.NewRouter(),
+		page:        NewPage(defaultStaticPath, defaultIndexPath),
+		PacketRecv:  dataIn,
+		OrderSend:   orderOut,
+		MessageRecv: messageIn,
 	}
 }
 
-func (server HTTPServer[R, S]) ListenAndServe() {
+func (server HTTPServer[D, O, M]) ListenAndServe() {
 	log.Fatalln(http.ListenAndServe(serverAddr, server.router))
 }

--- a/src/Shared/Server/infra/log.go
+++ b/src/Shared/Server/infra/log.go
@@ -1,0 +1,24 @@
+package infra
+
+import (
+	"io"
+	"log"
+	"net/http"
+)
+
+func (server HTTPServer[D, O, M]) HandleLog(route string, loggerEnable chan<- bool) {
+	server.router.Handle(route, LogHandle{logEnable: loggerEnable}).Methods("UPDATE")
+}
+
+type LogHandle struct {
+	logEnable chan<- bool
+}
+
+func (handler LogHandle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Fatalln("http server: log handle:", err)
+	}
+
+	handler.logEnable <- (string(body) == "enable")
+}

--- a/src/Shared/Server/infra/spa.go
+++ b/src/Shared/Server/infra/spa.go
@@ -32,3 +32,7 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
 }
+
+func (server HTTPServer[D, O, M]) HandleSPA() {
+	server.router.PathPrefix("/").Handler(server.page)
+}

--- a/src/Shared/Server/infra/websocket.go
+++ b/src/Shared/Server/infra/websocket.go
@@ -9,17 +9,24 @@ import (
 
 type Packet string
 
-func (server HTTPServer[R, S]) HandleWebSocketSend(route string, handler func(*websocket.Conn, chan S)) {
-	server.router.Handle(route, SocketHandle[S]{
+func (server HTTPServer[D, O, M]) HandleWebSocketOrder(route string, handler func(*websocket.Conn, chan O)) {
+	server.router.Handle(route, SocketHandle[O]{
 		function: handler,
 		channel:  server.OrderSend,
 	})
 }
 
-func (server HTTPServer[R, S]) HandleWebSocketRecv(route string, handler func(*websocket.Conn, chan R)) {
-	server.router.Handle(route, SocketHandle[R]{
+func (server HTTPServer[D, O, M]) HandleWebSocketData(route string, handler func(*websocket.Conn, chan D)) {
+	server.router.Handle(route, SocketHandle[D]{
 		function: handler,
 		channel:  server.PacketRecv,
+	})
+}
+
+func (server HTTPServer[D, O, M]) HandleWebSocketMessage(route string, handler func(*websocket.Conn, chan M)) {
+	server.router.Handle(route, SocketHandle[M]{
+		function: handler,
+		channel:  server.MessageRecv,
 	})
 }
 

--- a/src/Shared/StreamingHandlers/web_adapters.go
+++ b/src/Shared/StreamingHandlers/web_adapters.go
@@ -21,7 +21,7 @@ func newPacketWebAdapter(packet domain.Packet) PacketWebAdapter {
 		Name:         packet.Name,
 		Measurements: measurementWebAdapters,
 		Count:        packet.Count,
-		CycleTime:    packet.CycleTime,
+		CycleTime:    uint(packet.CycleTime),
 	}
 }
 


### PR DESCRIPTION
This PR modifies the logger and the web server so we can enable / disable the logger remotely from the frontend.

Some changes I did (to value_timestamp.go and web_adapters.go) is so that they dont give me errors when building