### PR TITLE
[PR6] DEV-70 add DataTransfer (after structure change)

### DIFF
--- a/src/data_transfer/data_transfer.go
+++ b/src/data_transfer/data_transfer.go
@@ -1,0 +1,41 @@
+package data_transfer
+
+import (
+	"time"
+
+	"github.com/HyperloopUPV-H8/Backend-H8/data_transfer/models"
+	"github.com/gorilla/websocket"
+)
+
+type DataTransfer struct {
+	routines []chan<- models.PacketUpdate
+	Rate     time.Duration
+}
+
+func (dataTransfer *DataTransfer) HandleConn(socket *websocket.Conn) {
+	updates := make(chan models.PacketUpdate)
+	dataTransfer.routines = append(dataTransfer.routines, updates)
+
+	go func(socket *websocket.Conn, updates <-chan models.PacketUpdate, rate time.Duration) {
+		defer socket.Close()
+		buf := make(map[uint16]models.PacketUpdate)
+		ticker := time.NewTicker(rate)
+	loop:
+		for {
+			select {
+			case payload := <-updates:
+				buf[payload.ID] = payload
+			case <-ticker.C:
+				if err := socket.WriteJSON(buf); err != nil {
+					break loop
+				}
+			}
+		}
+	}(socket, updates, dataTransfer.Rate)
+}
+
+func (dataTransfer *DataTransfer) Broadcast(update models.PacketUpdate) {
+	for _, routine := range dataTransfer.routines {
+		routine <- update
+	}
+}

--- a/src/data_transfer/models/packet_update.go
+++ b/src/data_transfer/models/packet_update.go
@@ -1,0 +1,9 @@
+package models
+
+type PacketUpdate struct {
+	ID        uint16            `json:"id"`
+	HexValue  string            `json:"hexValue"`
+	Count     uint64            `json:"count"`
+	CycleTime uint64            `json:"cycleTime"`
+	Values    map[string]string `json:"measurementUpdates"`
+}

--- a/src/data_transfer/models/pod_data.go
+++ b/src/data_transfer/models/pod_data.go
@@ -1,0 +1,96 @@
+package models
+
+import (
+	"log"
+	"strconv"
+	"strings"
+
+	excelAdapterModels "github.com/HyperloopUPV-H8/Backend-H8/excel_adapter/models"
+)
+
+type PodData struct {
+	Boards map[string]Board `json:"boards"`
+}
+
+func (podData *PodData) AddPacket(board string, ip string, desc excelAdapterModels.Description, values []excelAdapterModels.Value) {
+	if podData.Boards == nil {
+		podData.Boards = make(map[string]Board)
+	}
+
+	id, err := strconv.ParseUint(desc.ID, 10, 16)
+	if err != nil {
+		log.Fatalf("data transfer: AddPacket: %s\n", err)
+	}
+
+	dataBoard, ok := podData.Boards[board]
+	if !ok {
+		podData.Boards[board] = Board{
+			Name:    board,
+			Packets: make(map[uint16]Packet),
+		}
+		dataBoard = podData.Boards[board]
+	}
+
+	measurements := make(map[string]Measurement, len(values))
+	for _, value := range values {
+		measurements[value.Name] = Measurement{
+			Name:         value.Name,
+			Type:         value.Type,
+			Units:        value.DisplayUnits,
+			SafeRange:    parseRange(value.SafeRange),
+			WarningRange: parseRange(value.WarningRange),
+		}
+	}
+	dataBoard.Packets[uint16(id)] = Packet{
+		ID:           uint16(id),
+		Name:         desc.Name,
+		HexValue:     "",
+		Count:        0,
+		CycleTime:    0,
+		Measurements: measurements,
+	}
+}
+
+func parseRange(literal string) [2]float64 {
+	if literal == "" {
+		return [2]float64{0, 0}
+	}
+
+	split := strings.Split(strings.TrimSuffix(strings.TrimPrefix(literal, "["), "]"), ",")
+	if len(split) != 2 {
+		log.Fatalf("pod data: parseRange: invalid range %s\n", literal)
+	}
+	left, err := strconv.ParseFloat(split[0], 64)
+	if err != nil {
+		log.Fatalf("pod data: parseRange: %s\n", err)
+	}
+
+	right, err := strconv.ParseFloat(split[1], 64)
+	if err != nil {
+		log.Fatalf("pod data: parseRange: %s\n", err)
+	}
+
+	return [2]float64{left, right}
+}
+
+type Board struct {
+	Name    string            `json:"name"`
+	Packets map[uint16]Packet `json:"packets"`
+}
+
+type Packet struct {
+	ID           uint16                 `json:"id"`
+	Name         string                 `json:"name"`
+	HexValue     string                 `json:"hexValue"`
+	Count        uint16                 `json:"count"`
+	CycleTime    int64                  `json:"cycleTime"`
+	Measurements map[string]Measurement `json:"measurements"`
+}
+
+type Measurement struct {
+	Name         string     `json:"name"`
+	Type         string     `json:"type"`
+	Units        string     `json:"units"`
+	SafeRange    [2]float64 `json:"safeRange"`
+	WarningRange [2]float64 `json:"warningRange"`
+}

--- a/src/data_transfer/packet_factory.go
+++ b/src/data_transfer/packet_factory.go
@@ -1,0 +1,48 @@
+package data_transfer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/HyperloopUPV-H8/Backend-H8/data_transfer/models"
+)
+
+type PacketFactory struct {
+	count     map[uint16]uint64
+	timestamp map[uint16]uint64
+}
+
+func NewFactory() PacketFactory {
+	return PacketFactory{
+		count:     make(map[uint16]uint64),
+		timestamp: make(map[uint16]uint64),
+	}
+}
+
+func (factory PacketFactory) NewPacket(id uint16, raw []byte, values map[string]any) models.PacketUpdate {
+	count, cycleTime := factory.getNext(id)
+	return models.PacketUpdate{
+		ID:        id,
+		HexValue:  fmt.Sprintf("%x", raw),
+		Values:    formatValues(values),
+		Count:     count,
+		CycleTime: cycleTime,
+	}
+}
+
+func formatValues(values map[string]any) map[string]string {
+	mapped := make(map[string]string, len(values))
+	for name, val := range values {
+		mapped[name] = fmt.Sprintf("%v", val)
+	}
+	return mapped
+}
+
+func (factory PacketFactory) getNext(id uint16) (count uint64, cycleTime uint64) {
+	timestamp := uint64(time.Now().UnixNano())
+	cycleTime = timestamp - factory.timestamp[id]
+	factory.timestamp[id] = timestamp
+	factory.count[id] += 1
+	count = factory.count[id]
+	return
+}


### PR DESCRIPTION
DataTransfer takes all the incoming data decoded by the packetParser and sends it to the front.

The main difference relative to the last version is that now we support multiple webSocket connections open at the same time and all of them will recieve the packets.

Also now PodData is inside this module