### PR TITLE
[PR1] DEV-84 reduce logger footprint

### DIFF
--- a/src/log_handle/log.go
+++ b/src/log_handle/log.go
@@ -118,3 +118,11 @@ func (logger *LogHandle) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		log.Fatalf("log handle: HandleRequest: unexpected body %s\n", payload)
 	}
 }
+
+func (logger *LogHandle) Close() {
+	logger.filesMx.Lock()
+	defer logger.filesMx.Unlock()
+	for _, file := range logger.files {
+		file.Close()
+	}
+}

--- a/src/log_handle/log.go
+++ b/src/log_handle/log.go
@@ -51,7 +51,7 @@ func (logger *LogHandle) Update(updates map[string]any) {
 	}
 
 	if dump {
-		logger.dump()
+		go logger.dump()
 	}
 }
 

--- a/src/log_handle/models/config.go
+++ b/src/log_handle/models/config.go
@@ -1,11 +1,8 @@
 package models
 
-import "time"
-
 type Config struct {
-	DumpSize uint64
-	RowSize  uint64
-	Running  bool
-	Timeout  time.Ticker
-	BasePath string
+	DumpSize  uint64
+	RowSize   uint64
+	IsRunning bool
+	BasePath  string
 }

--- a/src/log_handle/models/value.go
+++ b/src/log_handle/models/value.go
@@ -3,7 +3,6 @@ package models
 import "time"
 
 type Value struct {
-	Name      string
 	Value     any
 	Timestamp time.Time
 }


### PR DESCRIPTION
The previous logger had a big footprint (even idle). These changes hope to alleviate those problems by reducing the amount of work it performs when not running and also simplifying it's operation when it does.

One of the tradeoffs I made was an autosave feature we had previously, which only complicated the design of the logger and made for a much more cumbersome API, we now only save the data when the buffers have a good amout of elements or when we stop the log session.